### PR TITLE
Use sh as interpreter for transform scripts

### DIFF
--- a/net/transform/transform_acopy.sh
+++ b/net/transform/transform_acopy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #ffmpeg -i $1 -y -f mp4 -map_metadata -1 -c:v copy -c:a copy $2
 #ffmpeg -f mp4 -i color=c=black:s=1280x720:r=5 -i $1 -crf 0 -c:a copy -shortest $2
 ffmpeg -i $1 -y -f mp3 -map_metadata -1 -c:a copy $2

--- a/net/transform/transform_icopy.sh
+++ b/net/transform/transform_icopy.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 convert -strip $1 -auto-orient $2
 

--- a/net/transform/transform_ilg.sh
+++ b/net/transform/transform_ilg.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 nice -n 5 convert -strip $1 -coalesce -auto-orient -resize '1024x1024>' $2
 

--- a/net/transform/transform_ithumb.sh
+++ b/net/transform/transform_ithumb.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 nice -n 5 convert -strip $1 -coalesce -auto-orient -resize '192x192' $2

--- a/net/transform/transform_vcopy.sh
+++ b/net/transform/transform_vcopy.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 ffmpeg -i $1 -y -f mp4 -map_metadata -1 -c:v copy -c:a copy $2
 

--- a/net/transform/transform_vhd.sh
+++ b/net/transform/transform_vhd.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 ffmpeg -i $1 -y -f mp4 -map_metadata -1 -vf scale=720:-2 -c:v libx264 -crf 23 -preset veryfast -c:a aac $2

--- a/net/transform/transform_vlq.sh
+++ b/net/transform/transform_vlq.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 ffmpeg -i $1 -y -f mp4 -map_metadata -1 -vf scale=320:-2 -c:v libx264 -crf 32 -preset veryfast -c:a aac $2
 

--- a/net/transform/transform_vsd.sh
+++ b/net/transform/transform_vsd.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 ffmpeg -i $1 -y -f mp4 -map_metadata -1 -vf scale=640:-2 -vcodec libx265 -crf 32 -preset veryfast -tag:v hvc1 -acodec mp3 $2

--- a/net/transform/transform_vthumb.sh
+++ b/net/transform/transform_vthumb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 TMPFILE=$(mktemp /tmp/databag-XXXXX)
 ffmpeg -ss $3 -i $1 -y -vframes 1 -q:v 2 $TMPFILE.jpg 


### PR DESCRIPTION
Fixed https://github.com/balzack/databag/issues/148

The new minified docker containers do not have `bash`, so the transform scripts were failing to execute.